### PR TITLE
fix typo: 'nase64' -> 'base64'

### DIFF
--- a/src/demo_utils/inference_engine.py
+++ b/src/demo_utils/inference_engine.py
@@ -108,7 +108,7 @@ class OpenaiEngine(Engine):
                 {"role": "system", "content": [{"type": "text", "text": prompt0}]},
                 {"role": "user",
                  "content": [{"type": "text", "text": prompt1}, {"type": "image_url", "image_url": {"url":
-                                                                                                        f"data:image/jpeg;nase64,{base64_image}",
+                                                                                                        f"data:image/jpeg;base64,{base64_image}",
                                                                                                     "detail": "high"},
                                                                  }]},
             ]

--- a/src/demo_utils/inference_engine.py
+++ b/src/demo_utils/inference_engine.py
@@ -128,7 +128,7 @@ class OpenaiEngine(Engine):
                 {"role": "system", "content": [{"type": "text", "text": prompt0}]},
                 {"role": "user",
                  "content": [{"type": "text", "text": prompt1}, {"type": "image_url", "image_url": {"url":
-                                                                                                        f"data:image/jpeg;nase64,{base64_image}",
+                                                                                                        f"data:image/jpeg;base64,{base64_image}",
                                                                                                     "detail": "high"}, }]},
                 {"role": "assistant", "content": [{"type": "text", "text": f"\n\n{ouput__0}"}]},
                 {"role": "user", "content": [{"type": "text", "text": prompt2}]}, ]


### PR DESCRIPTION
There seems a typo in the inference engine. GPTV API calling should use 'base64' rather than 'nase64', or there will be an error in the execution.