### PR TITLE
Add MiniMax M3 and M2.7 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Below is the list of currently supported models, to use any one of the model bel
 | OpenAI | gpt-4o | High | OPENAI_API_KEY in env |  |
 | Google | gemini-1.5-pro-latest | High | GEMINI_API_KEY in env | Rate limitting at 2 RPM by Google, need to add wait time in the code to work |
 | Ollama | llava | Low | N/A | Install Ollama, start Ollama, pull llava |
+| MiniMax | MiniMax-M3 | High | MINIMAX_API_KEY in env | Image input is supported through the OpenAI-compatible or Anthropic-compatible protocol |
 
 ## API Keys
 If you plan to use OpenAI family models, pass in the API Key in python or by environment variable
@@ -133,6 +134,26 @@ To use Gemini, pass in the API Key in python or by environment variable
 os.environ["GEMINI_API_KEY"] = "Your API KEY Here"
 ```
 Your Google API key is available at [Google AI Studio](https://aistudio.google.com/app/apikey).
+
+To use MiniMax image input, set `MINIMAX_API_KEY` and choose a compatible endpoint in the configuration file. The OpenAI-compatible protocol uses `api_base`:
+
+```toml
+[openai]
+model = "MiniMax-M3"
+protocol = "openai"
+api_base = "https://api.minimax.io/v1"
+```
+
+For the China endpoint, use `https://api.minimaxi.com/v1` as `api_base`. The Anthropic-compatible protocol uses the `/anthropic` base directly and appends `/v1/messages` for requests:
+
+```toml
+[openai]
+model = "MiniMax-M3"
+protocol = "anthropic"
+anthropic_base_url = "https://api.minimax.io/anthropic"
+```
+
+For the China Anthropic-compatible endpoint, use `https://api.minimaxi.com/anthropic` as `anthropic_base_url`.
 
 ## Configuration File
 An alternative to provide SeeActAgent input parameters is to use a config file, once the config file is provided, it will override all other input paramters.

--- a/seeact_package/seeact/demo_utils/inference_engine.py
+++ b/seeact_package/seeact/demo_utils/inference_engine.py
@@ -26,8 +26,13 @@ import requests
 from dotenv import load_dotenv
 import litellm
 import base64
+import httpx
+import mimetypes
 
 EMPTY_API_KEY="Your API KEY Here"
+MINIMAX_MODELS = {
+    "minimax-m3": "MiniMax-M3",
+}
 
 def load_openai_api_key():
     load_dotenv()
@@ -46,19 +51,70 @@ def load_gemini_api_key():
     ), "must pass on the api_key or set GEMINI_API_KEY in the environment"
     return os.getenv("GEMINI_API_KEY")
 
+
+def load_minimax_api_key():
+    load_dotenv()
+    assert (
+            os.getenv("MINIMAX_API_KEY") is not None and
+            os.getenv("MINIMAX_API_KEY") != EMPTY_API_KEY
+    ), "must pass on the api_key or set MINIMAX_API_KEY in the environment"
+    return os.getenv("MINIMAX_API_KEY")
+
+
+def resolve_minimax_base_url(protocol, configured_url):
+    if configured_url is None:
+        configured_url = os.getenv(
+            "MINIMAX_ANTHROPIC_BASE_URL" if protocol == "anthropic" else "MINIMAX_API_BASE_URL"
+        )
+    if not configured_url:
+        raise ValueError(
+            "configure a MiniMax base URL with api_base or anthropic_base_url"
+        )
+
+    base_url = configured_url.rstrip("/")
+    required_suffix = "/anthropic" if protocol == "anthropic" else "/v1"
+    if not base_url.endswith(required_suffix):
+        raise ValueError(f"MiniMax {protocol} base URL must end with {required_suffix}")
+    return base_url
+
 def encode_image(image_path):
     with open(image_path, "rb") as image_file:
         return base64.b64encode(image_file.read()).decode('utf-8')
 
 
-def engine_factory(api_key=None, model=None, **kwargs):
+def engine_factory(
+        api_key=None,
+        model=None,
+        protocol="openai",
+        api_base=None,
+        anthropic_base_url=None,
+        **kwargs,
+):
+    requested_model = model
     model = model.lower()
+    if model in MINIMAX_MODELS:
+        minimax_api_key = api_key if api_key and api_key != EMPTY_API_KEY else load_minimax_api_key()
+        if protocol == "openai":
+            return OpenAIEngine(
+                model=f"openai/{MINIMAX_MODELS[model]}",
+                api_key=minimax_api_key,
+                api_base=resolve_minimax_base_url(protocol, api_base),
+                **kwargs,
+            )
+        if protocol == "anthropic":
+            return AnthropicEngine(
+                model=MINIMAX_MODELS[model],
+                api_key=minimax_api_key,
+                api_base=resolve_minimax_base_url(protocol, anthropic_base_url),
+                **kwargs,
+            )
+        raise ValueError("MiniMax protocol must be openai or anthropic")
     if model in ["gpt-4-vision-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini"]:
         if api_key and api_key != EMPTY_API_KEY:
             os.environ["OPENAI_API_KEY"] = api_key
         else:
             load_openai_api_key()
-        return OpenAIEngine(model=model, **kwargs)
+        return OpenAIEngine(model=requested_model.lower(), **kwargs)
     elif model in ["gemini-1.5-pro-latest", "gemini-1.5-flash"]:
         if api_key and api_key != EMPTY_API_KEY:
             os.environ["GEMINI_API_KEY"] = api_key
@@ -79,6 +135,8 @@ class Engine:
             rate_limit=-1,
             model=None,
             temperature=0,
+            api_key=None,
+            api_base=None,
             **kwargs,
     ) -> None:
         """
@@ -94,6 +152,8 @@ class Engine:
         self.stop = stop
         self.temperature = temperature
         self.model = model
+        self.api_key = api_key
+        self.api_base = api_base
         # convert rate limit to minmum request interval
         self.request_interval = 0 if rate_limit == -1 else 60.0 / rate_limit
         self.next_avil_time = [0] * len(self.time_slots)
@@ -223,6 +283,14 @@ class OpenAIEngine(Engine):
         """
         super().__init__(**kwargs)
 
+    def _completion_kwargs(self, kwargs):
+        completion_kwargs = dict(kwargs)
+        if self.api_key is not None:
+            completion_kwargs.setdefault("api_key", self.api_key)
+        if self.api_base is not None:
+            completion_kwargs.setdefault("api_base", self.api_base)
+        return completion_kwargs
+
     @backoff.on_exception(
         backoff.expo,
         (APIError, RateLimitError, APIConnectionError),
@@ -265,9 +333,67 @@ class OpenAIEngine(Engine):
             messages=prompt_input,
             max_tokens=max_new_tokens if max_new_tokens else 4096,
             temperature=temperature if temperature else self.temperature,
-            **kwargs,
+            **self._completion_kwargs(kwargs),
         )
         return [choice["message"]["content"] for choice in response.choices][0]
+
+
+class AnthropicEngine(Engine):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        if not self.api_key:
+            raise ValueError("an API key is required for the Anthropic-compatible protocol")
+        if not self.api_base or not self.api_base.endswith("/anthropic"):
+            raise ValueError("the Anthropic-compatible base URL must end with /anthropic")
+
+    def _message_content(self, prompt, image_path):
+        content = [{"type": "text", "text": prompt}]
+        if image_path:
+            media_type = mimetypes.guess_type(image_path)[0] or "image/jpeg"
+            content.append({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": encode_image(image_path),
+                },
+            })
+        return content
+
+    def generate(self, prompt: list = None, max_new_tokens=4096, temperature=None, model=None, image_path=None,
+                 ouput_0=None, turn_number=0, **kwargs):
+        prompt0, prompt1, prompt2 = prompt
+        if turn_number == 0:
+            messages = [{"role": "user", "content": self._message_content(prompt1, image_path)}]
+        elif turn_number == 1:
+            messages = [
+                {"role": "user", "content": self._message_content(prompt1, image_path)},
+                {"role": "assistant", "content": f"\n\n{ouput_0}"},
+                {"role": "user", "content": prompt2},
+            ]
+        else:
+            raise ValueError("turn_number must be 0 or 1")
+
+        payload = {
+            "model": model if model else self.model,
+            "system": prompt0,
+            "messages": messages,
+            "max_tokens": max_new_tokens if max_new_tokens else 4096,
+            "temperature": temperature if temperature is not None else self.temperature,
+        }
+        response = httpx.post(
+            f"{self.api_base}/v1/messages",
+            headers={
+                "x-api-key": self.api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json=payload,
+            timeout=60,
+        )
+        response.raise_for_status()
+        content = response.json().get("content", [])
+        return "".join(block.get("text", "") for block in content if block.get("type") == "text")
 
 
 class OpenaiEngine_MindAct(Engine):

--- a/seeact_package/seeact/demo_utils/inference_engine.py
+++ b/seeact_package/seeact/demo_utils/inference_engine.py
@@ -32,6 +32,7 @@ import mimetypes
 EMPTY_API_KEY="Your API KEY Here"
 MINIMAX_MODELS = {
     "minimax-m3": "MiniMax-M3",
+    "minimax-m2.7": "MiniMax-M2.7",
 }
 
 def load_openai_api_key():

--- a/seeact_package/tests/test_inference_engine.py
+++ b/seeact_package/tests/test_inference_engine.py
@@ -25,6 +25,16 @@ class InferenceEngineTests(unittest.TestCase):
         self.assertEqual(engine.api_base, "https://api.minimaxi.com/v1")
         self.assertEqual(engine.api_key, "test-key")
 
+    def test_minimax_m27_is_registered(self):
+        engine = engine_factory(
+            api_key="test-key",
+            model="MiniMax-M2.7",
+            protocol="openai",
+            api_base="https://api.minimax.io/v1",
+        )
+
+        self.assertEqual(engine.model, "openai/MiniMax-M2.7")
+
     def test_minimax_openai_generation_sends_screenshot_content(self):
         with tempfile.NamedTemporaryFile(suffix=".jpg") as image_file:
             image_file.write(b"jpeg data")

--- a/seeact_package/tests/test_inference_engine.py
+++ b/seeact_package/tests/test_inference_engine.py
@@ -1,0 +1,102 @@
+import base64
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+PACKAGE_ROOT = Path(__file__).parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT))
+
+from seeact.demo_utils.inference_engine import engine_factory
+
+
+class InferenceEngineTests(unittest.TestCase):
+    def test_minimax_openai_configuration_preserves_model_and_base_url(self):
+        engine = engine_factory(
+            api_key="test-key",
+            model="MiniMax-M3",
+            protocol="openai",
+            api_base="https://api.minimaxi.com/v1",
+        )
+
+        self.assertEqual(engine.model, "openai/MiniMax-M3")
+        self.assertEqual(engine.api_base, "https://api.minimaxi.com/v1")
+        self.assertEqual(engine.api_key, "test-key")
+
+    def test_minimax_openai_generation_sends_screenshot_content(self):
+        with tempfile.NamedTemporaryFile(suffix=".jpg") as image_file:
+            image_file.write(b"jpeg data")
+            image_file.flush()
+
+            response = SimpleNamespace(choices=[{"message": {"content": "CLICK"}}])
+            with patch(
+                    "seeact.demo_utils.inference_engine.litellm.completion",
+                    return_value=response,
+            ) as completion:
+                engine = engine_factory(
+                    api_key="test-key",
+                    model="MiniMax-M3",
+                    protocol="openai",
+                    api_base="https://api.minimax.io/v1",
+                )
+                result = engine.generate(
+                    prompt=["system", "describe the screenshot", "choose an action"],
+                    image_path=image_file.name,
+                )
+
+        self.assertEqual(result, "CLICK")
+        request = completion.call_args.kwargs
+        self.assertEqual(request["model"], "openai/MiniMax-M3")
+        self.assertEqual(request["api_base"], "https://api.minimax.io/v1")
+        self.assertEqual(request["api_key"], "test-key")
+        image_url = request["messages"][1]["content"][1]["image_url"]["url"]
+        self.assertTrue(image_url.startswith("data:image/jpeg;base64,"))
+        self.assertEqual(base64.b64decode(image_url.split(",", 1)[1]), b"jpeg data")
+
+    def test_minimax_anthropic_configuration_sends_image_content(self):
+        with tempfile.NamedTemporaryFile(suffix=".png") as image_file:
+            image_file.write(b"png data")
+            image_file.flush()
+
+            class Response:
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    return {"content": [{"type": "text", "text": "CLICK"}]}
+
+            with patch("seeact.demo_utils.inference_engine.httpx.post", return_value=Response()) as post:
+                engine = engine_factory(
+                    api_key="test-key",
+                    model="MiniMax-M3",
+                    protocol="anthropic",
+                    anthropic_base_url="https://api.minimax.io/anthropic",
+                )
+                result = engine.generate(
+                    prompt=["system", "describe the screenshot", "choose an action"],
+                    image_path=image_file.name,
+                )
+
+        self.assertEqual(result, "CLICK")
+        url, request = post.call_args.args[0], post.call_args.kwargs
+        self.assertEqual(url, "https://api.minimax.io/anthropic/v1/messages")
+        self.assertEqual(request["headers"]["x-api-key"], "test-key")
+        image = request["json"]["messages"][0]["content"][1]
+        self.assertEqual(image["type"], "image")
+        self.assertEqual(image["source"]["media_type"], "image/png")
+        self.assertEqual(base64.b64decode(image["source"]["data"]), b"png data")
+
+    def test_minimax_anthropic_base_url_requires_anthropic_suffix(self):
+        with self.assertRaisesRegex(ValueError, "must end with /anthropic"):
+            engine_factory(
+                api_key="test-key",
+                model="MiniMax-M3",
+                protocol="anthropic",
+                anthropic_base_url="https://api.minimax.io/v1",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: add MiniMax-M3 and MiniMax-M2.7 through the existing SeeAct model integration.

Add MiniMax-M3 screenshot input with configurable regional endpoints across both supported API protocols. Register MiniMax-M2.7 in the model mapping and cover model selection plus the existing request paths with focused tests.

Checks:
- `uv pip install -e ./seeact_package`
- `uv run python -m unittest discover -s seeact_package/tests -p 'test_*.py' -v`
- `uv run python -m compileall -q seeact_package/seeact seeact_package/tests`
- `git diff --check`
